### PR TITLE
Add Smile Center React frontend scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# DentisSpiral
+# Smile Center - Frontend
+
+Aplicación frontend construida con React y Vite para el sistema de gestión de consultorio dental **Smile Center**. El objetivo es ofrecer una interfaz moderna para administrar pacientes, citas y reportes.
+
+## 🚀 Requisitos previos
+- Node.js >= 18
+- npm >= 9
+
+## 📦 Instalación
+```bash
+npm install
+```
+
+## ▶️ Ejecutar en modo desarrollo
+```bash
+npm run dev
+```
+
+El servidor se levantará por defecto en `http://localhost:5173`.
+
+## 🧭 Rutas principales
+- `/login` – Inicio de sesión para administradores y secretarias.
+- `/dashboard` – Panel principal con métricas, citas próximas y gráficas.
+- `/pacientes` – Directorio de pacientes con filtros y detalle.
+- `/citas` – Agenda con vista de calendario (FullCalendar).
+- `/reportes` – Visualización de reportes y estadísticas.
+- `/configuracion` – Ajustes generales del sistema.
+
+## 🧩 Dependencias destacadas
+- **react** & **react-dom** – Librería base para la UI.
+- **react-router-dom** – Manejo de rutas en el cliente.
+- **tailwindcss** – Estilos utilitarios.
+- **@fullcalendar/react** – Agenda de citas.
+- **recharts** – Visualización de gráficas.
+- **lucide-react** – Iconografía moderna.
+- **axios** – Cliente HTTP listo para integrar con APIs REST.
+
+## 🛠️ Estructura del proyecto
+```
+src/
+ ├─ components/
+ │   └─ ui/        # Componentes reutilizables estilo shadcn/ui
+ ├─ data/          # Datos mock para la UI
+ ├─ layouts/       # Layouts principales
+ ├─ pages/         # Vistas del sistema
+ └─ lib/           # Utilidades y cliente API
+```
+
+## 🔗 Integración con backend
+Los componentes están listos para conectarse a un backend Node.js mediante API REST usando `fetch` o `axios`. Las funciones de ejemplo se encuentran en `src/lib/utils.js` y pueden adaptarse para consumir los endpoints reales.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Smile Center</title>
+    <link rel="icon" type="image/svg+xml" href="/smile.svg" />
+  </head>
+  <body class="bg-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "smile-center",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint src --ext js,jsx"
+  },
+  "dependencies": {
+    "@fullcalendar/common": "^6.1.11",
+    "@fullcalendar/core": "^6.1.11",
+    "@fullcalendar/daygrid": "^6.1.11",
+    "@fullcalendar/interaction": "^6.1.11",
+    "@fullcalendar/react": "^6.1.11",
+    "axios": "^1.6.0",
+    "lucide-react": "^0.276.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.0",
+    "recharts": "^2.9.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.3",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react": "^7.33.2",
+    "postcss": "^8.4.27",
+    "tailwindcss": "^3.3.3",
+    "vite": "^4.4.9"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/smile.svg
+++ b/public/smile.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <rect width="128" height="128" rx="24" fill="#2563eb"/>
+  <path d="M64 96c-18 0-32-14-32-32" stroke="white" stroke-width="8" stroke-linecap="round"/>
+  <path d="M40 48c4 0 8-4 8-8s-4-8-8-8-8 4-8 8 4 8 8 8zm48 0c4 0 8-4 8-8s-4-8-8-8-8 4-8 8 4 8 8 8z" fill="white"/>
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,26 @@
+import { Route, Routes } from 'react-router-dom';
+import LoginPage from './pages/LoginPage.jsx';
+import DashboardPage from './pages/DashboardPage.jsx';
+import PatientsPage from './pages/PatientsPage.jsx';
+import AppointmentsPage from './pages/AppointmentsPage.jsx';
+import ReportsPage from './pages/ReportsPage.jsx';
+import SettingsPage from './pages/SettingsPage.jsx';
+import AppLayout from './layouts/AppLayout.jsx';
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route element={<AppLayout />}>
+        <Route path="/" element={<DashboardPage />} />
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/pacientes" element={<PatientsPage />} />
+        <Route path="/citas" element={<AppointmentsPage />} />
+        <Route path="/reportes" element={<ReportsPage />} />
+        <Route path="/configuracion" element={<SettingsPage />} />
+      </Route>
+    </Routes>
+  );
+}
+
+export default App;

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,0 +1,28 @@
+import { cn } from '../../lib/utils.js';
+
+const variants = {
+  default: 'bg-primary text-primary-foreground hover:bg-primary/90 shadow',
+  outline: 'border border-slate-200 bg-white hover:bg-slate-50',
+  ghost: 'hover:bg-slate-100'
+};
+
+const sizes = {
+  default: 'h-10 px-4 py-2',
+  sm: 'h-9 px-3',
+  lg: 'h-11 px-8',
+  icon: 'h-10 w-10'
+};
+
+export function Button({ className, variant = 'default', size = 'default', ...props }) {
+  return (
+    <button
+      className={cn(
+        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:pointer-events-none disabled:opacity-50',
+        variants[variant],
+        sizes[size],
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,0 +1,17 @@
+import { cn } from '../../lib/utils.js';
+
+export function Card({ className, ...props }) {
+  return <div className={cn('bg-white border border-slate-200 rounded-xl shadow-sm', className)} {...props} />;
+}
+
+export function CardHeader({ className, ...props }) {
+  return <div className={cn('p-6 border-b border-slate-100', className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }) {
+  return <h3 className={cn('text-lg font-semibold text-slate-700', className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }) {
+  return <div className={cn('p-6', className)} {...props} />;
+}

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -1,0 +1,11 @@
+import { cn } from '../../lib/utils.js';
+
+export const Input = ({ className, ...props }) => (
+  <input
+    className={cn(
+      'flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    {...props}
+  />
+);

--- a/src/components/ui/label.jsx
+++ b/src/components/ui/label.jsx
@@ -1,0 +1,5 @@
+import { cn } from '../../lib/utils.js';
+
+export function Label({ className, ...props }) {
+  return <label className={cn('text-sm font-medium text-slate-600', className)} {...props} />;
+}

--- a/src/data/mockData.js
+++ b/src/data/mockData.js
@@ -1,0 +1,91 @@
+export const metrics = {
+  patients: 320,
+  appointments: 128,
+  revenue: 48000,
+  currency: 'MXN'
+};
+
+export const upcomingAppointments = [
+  { id: 'CIT-001', patient: 'Juan Pérez', date: '2024-05-18T10:00:00', treatment: 'Limpieza dental', status: 'confirmada' },
+  { id: 'CIT-002', patient: 'María López', date: '2024-05-18T11:30:00', treatment: 'Ortodoncia', status: 'pendiente' },
+  { id: 'CIT-003', patient: 'Luis Gómez', date: '2024-05-18T14:00:00', treatment: 'Extracción', status: 'confirmada' },
+  { id: 'CIT-004', patient: 'Ana Martínez', date: '2024-05-18T16:30:00', treatment: 'Implante', status: 'pendiente' }
+];
+
+export const appointmentStats = [
+  { name: 'Atendidas', value: 92 },
+  { name: 'Canceladas', value: 8 }
+];
+
+export const revenueByMonth = [
+  { month: 'Ene', ingresos: 12000 },
+  { month: 'Feb', ingresos: 15000 },
+  { month: 'Mar', ingresos: 18000 },
+  { month: 'Abr', ingresos: 22000 },
+  { month: 'May', ingresos: 25000 }
+];
+
+export const treatmentStats = [
+  { name: 'Limpieza', value: 45 },
+  { name: 'Ortodoncia', value: 28 },
+  { name: 'Implantes', value: 18 },
+  { name: 'Resinas', value: 35 },
+  { name: 'Blanqueamiento', value: 22 }
+];
+
+export const attendanceStats = [
+  { name: 'Asistencias', value: 110 },
+  { name: 'Cancelaciones', value: 18 }
+];
+
+export const activePatients = [
+  { name: 'Juan Pérez', visits: 12 },
+  { name: 'María López', visits: 10 },
+  { name: 'Luis Gómez', visits: 9 },
+  { name: 'Ana Martínez', visits: 8 }
+];
+
+export const patientsDirectory = [
+  {
+    id: 'PAT-001',
+    name: 'Juan Pérez',
+    phone: '55 1234 5678',
+    email: 'juan.perez@example.com',
+    photo: 'https://i.pravatar.cc/150?img=3',
+    birthDate: '1988-07-12',
+    address: 'Av. Reforma 123, CDMX',
+    notes: 'Paciente con brackets. Control mensual.',
+    history: [
+      { date: '2024-04-10', treatment: 'Ajuste de brackets', cost: 1200, notes: 'Se ajusta arco superior.' },
+      { date: '2024-03-05', treatment: 'Limpieza dental', cost: 800, notes: 'Recomendado hilo dental diario.' }
+    ],
+    attachments: [
+      { name: 'Radiografía lateral.pdf', url: '#', size: '2.3MB' },
+      { name: 'Plan de tratamiento.pdf', url: '#', size: '1.1MB' }
+    ]
+  },
+  {
+    id: 'PAT-002',
+    name: 'María López',
+    phone: '55 8765 4321',
+    email: 'maria.lopez@example.com',
+    photo: 'https://i.pravatar.cc/150?img=5',
+    birthDate: '1992-02-24',
+    address: 'Calle Morelos 45, Naucalpan',
+    notes: 'Sensibilidad dental, usar pasta desensibilizante.',
+    history: [
+      { date: '2024-04-25', treatment: 'Resina dental', cost: 1500, notes: 'Control en 6 meses.' },
+      { date: '2024-02-15', treatment: 'Limpieza dental', cost: 800, notes: 'Sin complicaciones.' }
+    ],
+    attachments: [
+      { name: 'Presupuesto febrero.pdf', url: '#', size: '560KB' }
+    ]
+  }
+];
+
+export const appointmentsCalendar = [
+  { id: '1', title: 'Juan Pérez - Limpieza', date: '2024-05-18', status: 'confirmada' },
+  { id: '2', title: 'María López - Ortodoncia', date: '2024-05-19', status: 'pendiente' },
+  { id: '3', title: 'Luis Gómez - Implante', date: '2024-05-20', status: 'completada' },
+  { id: '4', title: 'Ana Martínez - Revisión', date: '2024-05-20', status: 'cancelada' }
+];

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,24 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply font-sans text-slate-900 bg-slate-100;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  @apply bg-slate-400 rounded-full;
+}

--- a/src/layouts/AppLayout.jsx
+++ b/src/layouts/AppLayout.jsx
@@ -1,0 +1,135 @@
+import { NavLink, Outlet, useNavigate } from 'react-router-dom';
+import { Button } from '../components/ui/button.jsx';
+import { cn } from '../lib/utils.js';
+import { LogOut, Menu, Settings, Users, Calendar, BarChart2, LayoutDashboard, X } from 'lucide-react';
+import { useState } from 'react';
+
+const navigation = [
+  { name: 'Dashboard', to: '/dashboard', icon: LayoutDashboard },
+  { name: 'Pacientes', to: '/pacientes', icon: Users },
+  { name: 'Citas', to: '/citas', icon: Calendar },
+  { name: 'Reportes', to: '/reportes', icon: BarChart2 },
+  { name: 'Configuración', to: '/configuracion', icon: Settings }
+];
+
+function SidebarContent({ collapsed = false, onItemClick = () => {}, onLogout = () => {} }) {
+  return (
+    <>
+      <div className={cn('flex items-center gap-3 px-6 py-4 border-b border-slate-200', collapsed && 'justify-center px-4')}>
+        <img src="/smile.svg" alt="Smile Center" className="h-10 w-10" />
+        {!collapsed && <div className="font-semibold text-lg text-slate-700">Smile Center</div>}
+      </div>
+      <nav className="flex-1 overflow-y-auto py-6 space-y-1 scrollbar-thin">
+        {navigation.map((item) => {
+          const Icon = item.icon;
+          return (
+            <NavLink
+              key={item.name}
+              to={item.to}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center gap-3 px-6 py-3 text-sm font-medium text-slate-600 hover:bg-slate-100 transition-colors',
+                  collapsed && 'justify-center px-4',
+                  isActive && 'bg-primary/10 text-primary shadow-sm'
+                )
+              }
+              onClick={onItemClick}
+            >
+              <Icon className="h-5 w-5" />
+              {!collapsed && <span className="truncate">{item.name}</span>}
+            </NavLink>
+          );
+        })}
+      </nav>
+      <div className={cn('px-6 pb-6', collapsed && 'px-4')}>
+        <Button variant="outline" className={cn('w-full', collapsed && 'justify-center px-0')} onClick={onLogout}>
+          <LogOut className={cn('h-4 w-4', !collapsed && 'mr-2')} />
+          {!collapsed && 'Cerrar sesión'}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function AppLayout() {
+  const navigate = useNavigate();
+  const [collapsed, setCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const handleLogout = () => {
+    setMobileOpen(false);
+    navigate('/login');
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-100">
+      <div className="flex">
+        <aside
+          className={cn(
+            'hidden md:flex md:flex-col bg-white border-r border-slate-200 min-h-screen transition-all duration-200',
+            collapsed ? 'md:w-20' : 'md:w-64'
+          )}
+        >
+          <SidebarContent collapsed={collapsed} onItemClick={() => {}} onLogout={handleLogout} />
+        </aside>
+
+        {mobileOpen && (
+          <div className="fixed inset-0 z-40 flex md:hidden">
+            <div className="absolute inset-0 bg-slate-900/40" onClick={() => setMobileOpen(false)} />
+            <aside className="relative z-50 w-72 bg-white border-r border-slate-200 flex flex-col">
+              <div className="flex items-center justify-between px-6 py-4 border-b border-slate-200">
+                <div className="flex items-center gap-3">
+                  <img src="/smile.svg" alt="Smile Center" className="h-10 w-10" />
+                  <div className="font-semibold text-lg text-slate-700">Smile Center</div>
+                </div>
+                <Button variant="ghost" size="icon" onClick={() => setMobileOpen(false)}>
+                  <X className="h-5 w-5" />
+                </Button>
+              </div>
+              <SidebarContent onItemClick={() => setMobileOpen(false)} onLogout={handleLogout} />
+            </aside>
+          </div>
+        )}
+
+        <div className="flex-1 flex flex-col">
+          <header className="sticky top-0 z-10 bg-white border-b border-slate-200">
+            <div className="flex items-center justify-between px-4 py-3">
+              <div className="flex items-center gap-3">
+                <Button variant="ghost" size="icon" className="md:hidden" onClick={() => setMobileOpen(true)}>
+                  <Menu className="h-5 w-5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="hidden md:flex"
+                  onClick={() => setCollapsed((prev) => !prev)}
+                  title={collapsed ? 'Expandir menú' : 'Colapsar menú'}
+                >
+                  <Menu className="h-5 w-5" />
+                </Button>
+                <div className="md:hidden flex items-center gap-2 font-semibold text-slate-700">
+                  <img src="/smile.svg" alt="Smile Center" className="h-8 w-8" />
+                  Smile Center
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <div className="text-sm text-slate-500 text-right">
+                  Secretaria Ana
+                  <p className="text-xs text-slate-400">Secretaria</p>
+                </div>
+                <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold">
+                  SA
+                </div>
+              </div>
+            </div>
+          </header>
+          <main className="flex-1 p-4 md:p-8">
+            <Outlet />
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AppLayout;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,20 @@
+export function cn(...classes) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export const apiClient = {
+  async get(path) {
+    const response = await fetch(path);
+    if (!response.ok) throw new Error('Error al cargar datos');
+    return response.json();
+  },
+  async post(path, body) {
+    const response = await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    if (!response.ok) throw new Error('Error al guardar datos');
+    return response.json();
+  }
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/AppointmentsPage.jsx
+++ b/src/pages/AppointmentsPage.jsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import '@fullcalendar/common/main.css';
+import '@fullcalendar/daygrid/main.css';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.jsx';
+import { Button } from '../components/ui/button.jsx';
+import { appointmentsCalendar } from '../data/mockData.js';
+
+const statusColors = {
+  pendiente: '#fbbf24',
+  confirmada: '#22c55e',
+  cancelada: '#ef4444',
+  completada: '#2563eb'
+};
+
+function AppointmentsPage() {
+  const events = useMemo(
+    () =>
+      appointmentsCalendar.map((event) => ({
+        ...event,
+        backgroundColor: statusColors[event.status],
+        borderColor: statusColors[event.status]
+      })),
+    []
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-700">Agenda de citas</h1>
+          <p className="text-sm text-slate-500">Visualiza y administra todas las citas programadas.</p>
+        </div>
+        <Button className="md:self-start">+ Nueva cita</Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Calendario de citas</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <FullCalendar
+            height="auto"
+            plugins={[dayGridPlugin, interactionPlugin]}
+            initialView="dayGridMonth"
+            locale="es"
+            events={events}
+            headerToolbar={{ left: 'prev,next today', center: 'title', right: 'dayGridMonth,dayGridWeek' }}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default AppointmentsPage;

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,0 +1,164 @@
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.jsx';
+import { Button } from '../components/ui/button.jsx';
+import { metrics, upcomingAppointments, appointmentStats, revenueByMonth } from '../data/mockData.js';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, LineChart, Line, XAxis, YAxis, CartesianGrid, Legend } from 'recharts';
+import { Calendar, DollarSign, Users } from 'lucide-react';
+
+const COLORS = ['#2563eb', '#cbd5f5'];
+
+function DashboardPage() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-700">Dashboard</h1>
+        <p className="text-sm text-slate-500">Resumen general de la clínica Smile Center</p>
+      </div>
+
+      <section className="grid gap-6 grid-cols-1 md:grid-cols-3">
+        <Card>
+          <CardHeader className="flex items-center justify-between">
+            <CardTitle>Total pacientes</CardTitle>
+            <Users className="h-5 w-5 text-primary" />
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-slate-700">{metrics.patients}</p>
+            <p className="text-xs text-slate-400 mt-1">+12% vs mes anterior</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex items-center justify-between">
+            <CardTitle>Total citas</CardTitle>
+            <Calendar className="h-5 w-5 text-primary" />
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-slate-700">{metrics.appointments}</p>
+            <p className="text-xs text-slate-400 mt-1">16 citas programadas hoy</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex items-center justify-between">
+            <CardTitle>Ingresos del mes</CardTitle>
+            <DollarSign className="h-5 w-5 text-primary" />
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold text-slate-700">
+              {new Intl.NumberFormat('es-MX', { style: 'currency', currency: metrics.currency }).format(metrics.revenue)}
+            </p>
+            <p className="text-xs text-slate-400 mt-1">+18% vs mes anterior</p>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <Card className="xl:col-span-2">
+          <CardHeader className="flex flex-row items-center justify-between">
+            <div>
+              <CardTitle>Citas próximas</CardTitle>
+              <p className="text-sm text-slate-500">Revisa la agenda del día</p>
+            </div>
+            <Button variant="outline">Ver agenda completa</Button>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {upcomingAppointments.map((appointment) => (
+              <div key={appointment.id} className="flex items-center justify-between rounded-lg border border-slate-200 p-4">
+                <div>
+                  <p className="text-sm font-semibold text-slate-700">{appointment.patient}</p>
+                  <p className="text-xs text-slate-500">{appointment.treatment}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-sm text-slate-500">
+                    {new Date(appointment.date).toLocaleDateString('es-MX', {
+                      hour: '2-digit',
+                      minute: '2-digit'
+                    })}
+                  </p>
+                  <span
+                    className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium capitalize ${
+                      appointment.status === 'confirmada'
+                        ? 'bg-green-100 text-green-600'
+                        : appointment.status === 'pendiente'
+                        ? 'bg-amber-100 text-amber-600'
+                        : 'bg-slate-100 text-slate-600'
+                    }`}
+                  >
+                    {appointment.status}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Citas atendidas vs canceladas</CardTitle>
+          </CardHeader>
+          <CardContent className="h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie data={appointmentStats} dataKey="value" nameKey="name" innerRadius={60} outerRadius={90} paddingAngle={4}>
+                  {appointmentStats.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip />
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Ingresos por mes</CardTitle>
+          </CardHeader>
+          <CardContent className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={revenueByMonth}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                <XAxis dataKey="month" stroke="#94a3b8" />
+                <YAxis stroke="#94a3b8" tickFormatter={(value) => `$${value / 1000}k`} />
+                <Tooltip formatter={(value) => new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(value)} />
+                <Line type="monotone" dataKey="ingresos" stroke="#2563eb" strokeWidth={3} dot={{ r: 5 }} />
+              </LineChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Recordatorios rápidos</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-start gap-3">
+              <span className="h-2 w-2 rounded-full bg-primary mt-2" />
+              <div>
+                <p className="text-sm font-medium text-slate-700">Enviar confirmaciones de citas de mañana</p>
+                <p className="text-xs text-slate-500">Programa envíos automáticos antes de las 18:00 hrs.</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <span className="h-2 w-2 rounded-full bg-primary mt-2" />
+              <div>
+                <p className="text-sm font-medium text-slate-700">Revisar inventario de materiales</p>
+                <p className="text-xs text-slate-500">Actualiza la lista de compras para la próxima semana.</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <span className="h-2 w-2 rounded-full bg-primary mt-2" />
+              <div>
+                <p className="text-sm font-medium text-slate-700">Contactar a pacientes inactivos</p>
+                <p className="text-xs text-slate-500">Envía recordatorios a pacientes con más de 6 meses sin consulta.</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}
+
+export default DashboardPage;

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '../components/ui/button.jsx';
+import { Input } from '../components/ui/input.jsx';
+import { Label } from '../components/ui/label.jsx';
+
+function LoginPage() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ username: '', password: '' });
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    // TODO: replace with real API authentication
+    navigate('/dashboard');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-slate-100 px-4">
+      <div className="max-w-md w-full bg-white shadow-xl rounded-2xl p-10 border border-slate-200">
+        <div className="flex flex-col items-center text-center mb-8">
+          <img src="/smile.svg" alt="Smile Center" className="h-16 w-16 mb-4" />
+          <h1 className="text-2xl font-semibold text-slate-700">Smile Center</h1>
+          <p className="text-sm text-slate-500">Gestión inteligente de pacientes y citas</p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2 text-left">
+            <Label htmlFor="username">Usuario</Label>
+            <Input
+              id="username"
+              placeholder="Correo o nombre de usuario"
+              value={form.username}
+              onChange={(event) => setForm({ ...form, username: event.target.value })}
+              required
+            />
+          </div>
+          <div className="space-y-2 text-left">
+            <Label htmlFor="password">Contraseña</Label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="••••••••"
+              value={form.password}
+              onChange={(event) => setForm({ ...form, password: event.target.value })}
+              required
+            />
+          </div>
+          <div className="text-right">
+            <a href="#" className="text-sm text-primary hover:underline">
+              ¿Olvidaste tu contraseña?
+            </a>
+          </div>
+          <Button type="submit" className="w-full">
+            Iniciar sesión
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default LoginPage;

--- a/src/pages/PatientsPage.jsx
+++ b/src/pages/PatientsPage.jsx
@@ -1,0 +1,124 @@
+import { useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.jsx';
+import { Input } from '../components/ui/input.jsx';
+import { Button } from '../components/ui/button.jsx';
+import { patientsDirectory } from '../data/mockData.js';
+
+function PatientsPage() {
+  const [query, setQuery] = useState('');
+  const [selectedPatient, setSelectedPatient] = useState(patientsDirectory[0]);
+
+  const filteredPatients = useMemo(() => {
+    return patientsDirectory.filter((patient) =>
+      patient.name.toLowerCase().includes(query.toLowerCase()) || patient.email.toLowerCase().includes(query.toLowerCase())
+    );
+  }, [query]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-700">Pacientes</h1>
+          <p className="text-sm text-slate-500">Gestiona y consulta el historial completo de tus pacientes.</p>
+        </div>
+        <Button>+ Nuevo paciente</Button>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <Card className="xl:col-span-2">
+          <CardHeader className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <CardTitle>Directorio de pacientes</CardTitle>
+            <Input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Buscar por nombre o correo" />
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-200">
+              <thead className="bg-slate-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Paciente</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Teléfono</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Correo</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Acciones</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-slate-200">
+                {filteredPatients.map((patient) => (
+                  <tr key={patient.id} className="hover:bg-slate-50">
+                    <td className="px-4 py-4">
+                      <div className="flex items-center gap-3">
+                        <img src={patient.photo} alt={patient.name} className="h-10 w-10 rounded-full object-cover" />
+                        <div>
+                          <p className="text-sm font-semibold text-slate-700">{patient.name}</p>
+                          <p className="text-xs text-slate-500">ID {patient.id}</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-4 text-sm text-slate-600">{patient.phone}</td>
+                    <td className="px-4 py-4 text-sm text-slate-600">{patient.email}</td>
+                    <td className="px-4 py-4 text-right">
+                      <Button variant="outline" onClick={() => setSelectedPatient(patient)}>
+                        Ver detalle
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {filteredPatients.length === 0 && (
+              <p className="text-sm text-slate-500 text-center py-6">No se encontraron pacientes con ese criterio.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        {selectedPatient && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Detalle del paciente</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="flex flex-col items-center text-center space-y-3">
+                <img src={selectedPatient.photo} alt={selectedPatient.name} className="h-20 w-20 rounded-full object-cover" />
+                <div>
+                  <h3 className="text-lg font-semibold text-slate-700">{selectedPatient.name}</h3>
+                  <p className="text-xs text-slate-500">{selectedPatient.email}</p>
+                </div>
+              </div>
+              <div className="space-y-2 text-sm">
+                <p><span className="font-semibold">ID:</span> {selectedPatient.id}</p>
+                <p><span className="font-semibold">Fecha de nacimiento:</span> {selectedPatient.birthDate}</p>
+                <p><span className="font-semibold">Teléfono:</span> {selectedPatient.phone}</p>
+                <p><span className="font-semibold">Dirección:</span> {selectedPatient.address}</p>
+                <p><span className="font-semibold">Notas:</span> {selectedPatient.notes}</p>
+              </div>
+              <div>
+                <h4 className="text-sm font-semibold text-slate-600 mb-3">Historial de consultas</h4>
+                <div className="space-y-3">
+                  {selectedPatient.history.map((item) => (
+                    <div key={item.date} className="border border-slate-200 rounded-lg p-3">
+                      <p className="text-sm font-semibold text-slate-700">{item.treatment}</p>
+                      <p className="text-xs text-slate-500">{item.date}</p>
+                      <p className="text-xs text-slate-500">Costo: ${item.cost}</p>
+                      <p className="text-xs text-slate-500">{item.notes}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <h4 className="text-sm font-semibold text-slate-600 mb-3">Archivos adjuntos</h4>
+                <div className="space-y-2">
+                  {selectedPatient.attachments.map((file) => (
+                    <a key={file.name} href={file.url} className="flex items-center justify-between text-sm text-primary hover:underline">
+                      <span>{file.name}</span>
+                      <span className="text-xs text-slate-400">{file.size}</span>
+                    </a>
+                  ))}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PatientsPage;

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -1,0 +1,72 @@
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.jsx';
+import { treatmentStats, attendanceStats, activePatients } from '../data/mockData.js';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, PieChart, Pie, Cell } from 'recharts';
+
+const COLORS = ['#2563eb', '#60a5fa', '#1d4ed8', '#3b82f6', '#bfdbfe'];
+
+function ReportsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-700">Reportes</h1>
+        <p className="text-sm text-slate-500">Analiza el desempeño del consultorio y tendencias de pacientes.</p>
+      </div>
+
+      <section className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Tratamientos más frecuentes</CardTitle>
+          </CardHeader>
+          <CardContent className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={treatmentStats}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                <XAxis dataKey="name" stroke="#94a3b8" />
+                <YAxis stroke="#94a3b8" />
+                <Tooltip />
+                <Bar dataKey="value" fill="#2563eb" radius={[8, 8, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Cancelaciones vs asistencias</CardTitle>
+          </CardHeader>
+          <CardContent className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie data={attendanceStats} dataKey="value" nameKey="name" innerRadius={60} outerRadius={90}>
+                  {attendanceStats.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </section>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Pacientes más activos</CardTitle>
+        </CardHeader>
+        <CardContent className="h-80">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={activePatients} layout="vertical" margin={{ left: 80 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+              <XAxis type="number" stroke="#94a3b8" />
+              <YAxis dataKey="name" type="category" stroke="#94a3b8" />
+              <Tooltip />
+              <Bar dataKey="visits" fill="#60a5fa" radius={[0, 8, 8, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default ReportsPage;

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,0 +1,27 @@
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.jsx';
+import { Button } from '../components/ui/button.jsx';
+
+function SettingsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-700">Configuración</h1>
+        <p className="text-sm text-slate-500">Personaliza la información del consultorio y las preferencias del sistema.</p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Preferencias generales</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <p className="text-sm font-semibold text-slate-700">Integraciones</p>
+            <p className="text-xs text-slate-500">Configura la sincronización con tu sistema contable y recordatorios SMS.</p>
+          </div>
+          <Button variant="outline">Conectar integraciones</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default SettingsPage;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,19 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#2563eb',
+          foreground: '#ffffff'
+        }
+      },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui']
+      }
+    }
+  },
+  plugins: []
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React project configured with Tailwind and reusable shadcn-style UI primitives for the Smile Center web app
- implement authenticated layout, sidebar navigation, and pages for dashboard, patients, appointments calendar, reports, and settings backed by mock data
- document setup instructions and project structure in the README for future backend integration

## Testing
- npm install *(fails: registry access returns 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dc8093672c8325830bd65c829044b2