### PR TITLE
Implementar layout y vistas principales

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,28 +1,37 @@
-import React, { useRef } from 'react'
-import FullCalendar from '@fullcalendar/react'
-import dayGridPlugin from '@fullcalendar/daygrid'
-import timeGridPlugin from '@fullcalendar/timegrid'
-import interactionPlugin from '@fullcalendar/interaction'
+import { useRef } from 'react';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import '@fullcalendar/core/index.css';
+import '@fullcalendar/daygrid/index.css';
+import '@fullcalendar/timegrid/index.css';
 
-export default function Calendar() {
-  const calendarRef = useRef(null)
+export default function Calendar({ events = [] }) {
+  const calendarRef = useRef(null);
 
   return (
-    <div style={{ background: '#fff', padding: 16, borderRadius: 8 }}>
+    <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
       <FullCalendar
         ref={calendarRef}
         plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
         initialView="dayGridMonth"
+        height="auto"
         headerToolbar={{
           left: 'prev,next today',
           center: 'title',
           right: 'dayGridMonth,timeGridWeek,timeGridDay'
         }}
-        events={[
-          { title: 'Cita - Juan Pérez', date: '2025-10-01' },
-          { title: 'Limpieza - Ana', date: '2025-10-02' }
-        ]}
+        buttonText={{
+          today: 'Hoy',
+          month: 'Mes',
+          week: 'Semana',
+          day: 'Día'
+        }}
+        events={events}
+        eventColor="#1f2937"
+        eventTextColor="#ffffff"
       />
     </div>
-  )
+  );
 }

--- a/src/data/pacientes.js
+++ b/src/data/pacientes.js
@@ -1,0 +1,152 @@
+export const patientsData = [
+  {
+    id: 'pat-001',
+    name: 'Juan Pérez',
+    phone: '55 1234 5678',
+    email: 'juan.perez@example.com',
+    photo: 'https://i.pravatar.cc/150?img=12',
+    birthDate: '1988-07-12',
+    address: 'Av. Reforma 123, Ciudad de México',
+    lastVisit: '2024-04-12',
+    notes: 'Tratamiento de ortodoncia activo. Revisar alineación en la próxima cita.',
+    history: [
+      { date: '2024-04-12', treatment: 'Ajuste de brackets', status: 'Completado' },
+      { date: '2024-03-10', treatment: 'Limpieza dental', status: 'Completado' }
+    ]
+  },
+  {
+    id: 'pat-002',
+    name: 'María López',
+    phone: '55 8765 4321',
+    email: 'maria.lopez@example.com',
+    photo: 'https://i.pravatar.cc/150?img=32',
+    birthDate: '1990-02-24',
+    address: 'Calle Morelos 45, Naucalpan',
+    lastVisit: '2024-05-02',
+    notes: 'Sensibilidad dental. Recomendar pasta especial y enjuague.',
+    history: [
+      { date: '2024-05-02', treatment: 'Resina dental', status: 'Completado' },
+      { date: '2024-02-18', treatment: 'Limpieza dental', status: 'Completado' }
+    ]
+  },
+  {
+    id: 'pat-003',
+    name: 'Luis Gómez',
+    phone: '55 4321 8765',
+    email: 'luis.gomez@example.com',
+    photo: 'https://i.pravatar.cc/150?img=36',
+    birthDate: '1985-11-03',
+    address: 'Av. Universidad 678, Coyoacán',
+    lastVisit: '2024-03-22',
+    notes: 'Implante molar realizado. Revisar cicatrización.',
+    history: [
+      { date: '2024-03-22', treatment: 'Implante dental', status: 'Completado' },
+      { date: '2024-01-15', treatment: 'Evaluación general', status: 'Completado' }
+    ]
+  },
+  {
+    id: 'pat-004',
+    name: 'Ana Martínez',
+    phone: '55 9988 7766',
+    email: 'ana.martinez@example.com',
+    photo: 'https://i.pravatar.cc/150?img=47',
+    birthDate: '1993-09-15',
+    address: 'Circuito Médicos 234, Satélite',
+    lastVisit: '2024-04-28',
+    notes: 'Seguimiento de blanqueamiento dental. Evaluar sensibilidad.',
+    history: [
+      { date: '2024-04-28', treatment: 'Control de blanqueamiento', status: 'Completado' },
+      { date: '2024-03-12', treatment: 'Blanqueamiento dental', status: 'Completado' }
+    ]
+  },
+  {
+    id: 'pat-005',
+    name: 'Carlos Hernández',
+    phone: '55 2233 4455',
+    email: 'carlos.hernandez@example.com',
+    photo: 'https://i.pravatar.cc/150?img=52',
+    birthDate: '1978-12-08',
+    address: 'Av. Insurgentes 901, CDMX',
+    lastVisit: '2024-02-20',
+    notes: 'Prótesis parcial reciente. Ajustar en próxima cita.',
+    history: [
+      { date: '2024-02-20', treatment: 'Ajuste de prótesis', status: 'Completado' },
+      { date: '2023-12-15', treatment: 'Colocación de prótesis', status: 'Completado' }
+    ]
+  },
+  {
+    id: 'pat-006',
+    name: 'Sofía Ramírez',
+    phone: '55 6677 8899',
+    email: 'sofia.ramirez@example.com',
+    photo: 'https://i.pravatar.cc/150?img=58',
+    birthDate: '1995-05-30',
+    address: 'Av. Central 45, Ecatepec',
+    lastVisit: '2024-05-09',
+    notes: 'Revisión anual completada. Programar limpieza en 6 meses.',
+    history: [
+      { date: '2024-05-09', treatment: 'Revisión general', status: 'Completado' },
+      { date: '2023-10-10', treatment: 'Limpieza dental', status: 'Completado' }
+    ]
+  },
+  {
+    id: 'pat-007',
+    name: 'Diego Torres',
+    phone: '55 3344 5566',
+    email: 'diego.torres@example.com',
+    photo: 'https://i.pravatar.cc/150?img=59',
+    birthDate: '1982-03-21',
+    address: 'Calle Sur 123, Iztapalapa',
+    lastVisit: '2024-01-30',
+    notes: 'Tratamiento periodontal. Requiere seguimiento trimestral.',
+    history: [
+      { date: '2024-01-30', treatment: 'Control periodontal', status: 'Completado' },
+      { date: '2023-11-18', treatment: 'Limpieza profunda', status: 'Completado' }
+    ]
+  },
+  {
+    id: 'pat-008',
+    name: 'Paola Méndez',
+    phone: '55 7788 9900',
+    email: 'paola.mendez@example.com',
+    photo: 'https://i.pravatar.cc/150?img=60',
+    birthDate: '1998-08-05',
+    address: 'Av. Jardines 67, Tlalnepantla',
+    lastVisit: '2024-03-05',
+    notes: 'Caries tratada recientemente. Reforzar higiene dental.',
+    history: [
+      { date: '2024-03-05', treatment: 'Resina dental', status: 'Completado' },
+      { date: '2023-09-14', treatment: 'Limpieza dental', status: 'Completado' }
+    ]
+  },
+  {
+    id: 'pat-009',
+    name: 'Fernando Ruiz',
+    phone: '55 1122 3344',
+    email: 'fernando.ruiz@example.com',
+    photo: 'https://i.pravatar.cc/150?img=64',
+    birthDate: '1975-01-11',
+    address: 'Calz. de Tlalpan 234, CDMX',
+    lastVisit: '2024-04-18',
+    notes: 'Tratamiento de conducto completado. Control en 3 meses.',
+    history: [
+      { date: '2024-04-18', treatment: 'Tratamiento de conducto', status: 'Completado' },
+      { date: '2024-02-01', treatment: 'Evaluación general', status: 'Completado' }
+    ]
+  },
+  {
+    id: 'pat-010',
+    name: 'Laura García',
+    phone: '55 4455 6677',
+    email: 'laura.garcia@example.com',
+    photo: 'https://i.pravatar.cc/150?img=65',
+    birthDate: '1987-10-19',
+    address: 'Av. Palmas 345, CDMX',
+    lastVisit: '2024-02-27',
+    notes: 'Uso de retenedores. Revisar ajuste en la siguiente cita.',
+    history: [
+      { date: '2024-02-27', treatment: 'Ajuste de retenedores', status: 'Completado' },
+      { date: '2023-12-02', treatment: 'Retiro de brackets', status: 'Completado' }
+    ]
+  }
+];

--- a/src/layouts/AppLayout.jsx
+++ b/src/layouts/AppLayout.jsx
@@ -1,129 +1,58 @@
-import { NavLink, Outlet, useNavigate } from 'react-router-dom';
-import { Button } from '../components/ui/button.jsx';
-import { cn } from '../lib/utils.js';
-import { LogOut, Menu, Settings, Users, Calendar, BarChart2, LayoutDashboard, X } from 'lucide-react';
-import { useState } from 'react';
+import { NavLink, Outlet } from 'react-router-dom';
+import { LayoutDashboard, Users, CalendarDays, BarChart3 } from 'lucide-react';
 
 const navigation = [
   { name: 'Dashboard', to: '/dashboard', icon: LayoutDashboard },
   { name: 'Pacientes', to: '/pacientes', icon: Users },
-  { name: 'Citas', to: '/citas', icon: Calendar },
-  { name: 'Reportes', to: '/reportes', icon: BarChart2 },
-  { name: 'Configuración', to: '/configuracion', icon: Settings }
+  { name: 'Citas', to: '/citas', icon: CalendarDays },
+  { name: 'Reportes', to: '/reportes', icon: BarChart3 }
 ];
 
-function SidebarContent({ collapsed = false, onItemClick = () => {}, onLogout = () => {} }) {
-  return (
-    <>
-      <div className={cn('flex items-center gap-3 px-6 py-4 border-b border-slate-200', collapsed && 'justify-center px-4')}>
-        <img src="/smile.svg" alt="Smile Center" className="h-10 w-10" />
-        {!collapsed && <div className="font-semibold text-lg text-slate-700">Smile Center</div>}
-      </div>
-      <nav className="flex-1 overflow-y-auto py-6 space-y-1 scrollbar-thin">
-        {navigation.map((item) => {
-          const Icon = item.icon;
-          return (
-            <NavLink
-              key={item.name}
-              to={item.to}
-              className={({ isActive }) =>
-                cn(
-                  'flex items-center gap-3 px-6 py-3 text-sm font-medium text-slate-600 hover:bg-slate-100 transition-colors',
-                  collapsed && 'justify-center px-4',
-                  isActive && 'bg-primary/10 text-primary shadow-sm'
-                )
-              }
-              onClick={onItemClick}
-            >
-              <Icon className="h-5 w-5" />
-              {!collapsed && <span className="truncate">{item.name}</span>}
-            </NavLink>
-          );
-        })}
-      </nav>
-      <div className={cn('px-6 pb-6', collapsed && 'px-4')}>
-        <Button variant="outline" className={cn('w-full', collapsed && 'justify-center px-0')} onClick={onLogout}>
-          <LogOut className={cn('h-4 w-4', !collapsed && 'mr-2')} />
-          {!collapsed && 'Cerrar sesión'}
-        </Button>
-      </div>
-    </>
-  );
-}
+const linkBaseClasses =
+  'flex items-center gap-3 rounded-lg px-4 py-2 text-sm font-medium transition-colors';
 
 function AppLayout() {
-  const navigate = useNavigate();
-  const [collapsed, setCollapsed] = useState(false);
-  const [mobileOpen, setMobileOpen] = useState(false);
-
-  const handleLogout = () => {
-    setMobileOpen(false);
-    navigate('/login');
-  };
-
   return (
-    <div className="min-h-screen bg-slate-100">
-      <div className="flex">
-        <aside
-          className={cn(
-            'hidden md:flex md:flex-col bg-white border-r border-slate-200 min-h-screen transition-all duration-200',
-            collapsed ? 'md:w-20' : 'md:w-64'
-          )}
-        >
-          <SidebarContent collapsed={collapsed} onItemClick={() => {}} onLogout={handleLogout} />
+    <div className="min-h-screen bg-slate-100 text-slate-800">
+      <div className="flex min-h-screen">
+        <aside className="w-60 shrink-0 border-r border-slate-200 bg-white px-4 py-6">
+          <div className="mb-8 px-2 text-2xl font-semibold text-slate-900">Smile Center</div>
+          <nav className="flex flex-col gap-1">
+            {navigation.map(({ name, to, icon: Icon }) => (
+              <NavLink
+                key={to}
+                to={to}
+                className={({ isActive }) =>
+                  [
+                    linkBaseClasses,
+                    isActive
+                      ? 'bg-slate-900 text-white shadow-sm'
+                      : 'text-slate-600 hover:bg-slate-100'
+                  ].join(' ')
+                }
+              >
+                <Icon className="h-4 w-4" />
+                <span>{name}</span>
+              </NavLink>
+            ))}
+          </nav>
         </aside>
 
-        {mobileOpen && (
-          <div className="fixed inset-0 z-40 flex md:hidden">
-            <div className="absolute inset-0 bg-slate-900/40" onClick={() => setMobileOpen(false)} />
-            <aside className="relative z-50 w-72 bg-white border-r border-slate-200 flex flex-col">
-              <div className="flex items-center justify-between px-6 py-4 border-b border-slate-200">
-                <div className="flex items-center gap-3">
-                  <img src="/smile.svg" alt="Smile Center" className="h-10 w-10" />
-                  <div className="font-semibold text-lg text-slate-700">Smile Center</div>
-                </div>
-                <Button variant="ghost" size="icon" onClick={() => setMobileOpen(false)}>
-                  <X className="h-5 w-5" />
-                </Button>
+        <div className="flex flex-1 flex-col">
+          <header className="flex items-center justify-between border-b border-slate-200 bg-white px-4 py-4 shadow-sm md:px-8">
+            <div className="text-lg font-semibold">Panel administrativo</div>
+            <div className="flex items-center gap-3">
+              <div className="hidden text-right text-sm text-slate-500 sm:block">
+                Bienvenida,
+                <span className="block font-medium text-slate-700">Secretaria Ana</span>
               </div>
-              <SidebarContent onItemClick={() => setMobileOpen(false)} onLogout={handleLogout} />
-            </aside>
-          </div>
-        )}
-
-        <div className="flex-1 flex flex-col">
-          <header className="sticky top-0 z-10 bg-white border-b border-slate-200">
-            <div className="flex items-center justify-between px-4 py-3">
-              <div className="flex items-center gap-3">
-                <Button variant="ghost" size="icon" className="md:hidden" onClick={() => setMobileOpen(true)}>
-                  <Menu className="h-5 w-5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="hidden md:flex"
-                  onClick={() => setCollapsed((prev) => !prev)}
-                  title={collapsed ? 'Expandir menú' : 'Colapsar menú'}
-                >
-                  <Menu className="h-5 w-5" />
-                </Button>
-                <div className="md:hidden flex items-center gap-2 font-semibold text-slate-700">
-                  <img src="/smile.svg" alt="Smile Center" className="h-8 w-8" />
-                  Smile Center
-                </div>
-              </div>
-              <div className="flex items-center gap-3">
-                <div className="text-sm text-slate-500 text-right">
-                  Secretaria Ana
-                  <p className="text-xs text-slate-400">Secretaria</p>
-                </div>
-                <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center text-primary font-semibold">
-                  SA
-                </div>
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-900 text-sm font-semibold text-white">
+                SA
               </div>
             </div>
           </header>
-          <main className="flex-1 p-4 md:p-8">
+
+          <main className="flex-1 bg-slate-100 px-4 py-6 md:px-8">
             <Outlet />
           </main>
         </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,28 @@
-import React from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.jsx'
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import AppLayout from './layouts/AppLayout.jsx';
+import Dashboard from './pages/Dashboard.jsx';
+import Pacientes from './pages/Pacientes.jsx';
+import PacienteDetalle from './pages/PacienteDetalle.jsx';
+import Citas from './pages/Citas.jsx';
+import Reportes from './pages/Reportes.jsx';
+import './index.css';
 
-const root = createRoot(document.getElementById('root'))
-root.render(<App />)
+const rootElement = document.getElementById('root');
+const root = createRoot(rootElement);
+
+root.render(
+  <BrowserRouter>
+    <Routes>
+      <Route path="/" element={<AppLayout />}>
+        <Route index element={<Navigate to="/dashboard" replace />} />
+        <Route path="dashboard" element={<Dashboard />} />
+        <Route path="pacientes" element={<Pacientes />} />
+        <Route path="pacientes/:id" element={<PacienteDetalle />} />
+        <Route path="citas" element={<Citas />} />
+        <Route path="reportes" element={<Reportes />} />
+      </Route>
+      <Route path="*" element={<Navigate to="/dashboard" replace />} />
+    </Routes>
+  </BrowserRouter>
+);

--- a/src/pages/Citas.jsx
+++ b/src/pages/Citas.jsx
@@ -1,0 +1,28 @@
+import Calendar from '../components/Calendar.jsx';
+
+const events = [
+  { title: 'Limpieza · Juan Pérez', date: '2024-05-21T10:00:00' },
+  { title: 'Ortodoncia · María López', date: '2024-05-21T12:30:00' },
+  { title: 'Implante · Luis Gómez', date: '2024-05-22T09:00:00' }
+];
+
+export default function Citas() {
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">Agenda de citas</h1>
+          <p className="text-sm text-slate-500">Consulta las citas programadas por día, semana o mes.</p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-slate-700"
+        >
+          + Nueva cita
+        </button>
+      </div>
+
+      <Calendar events={events} />
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,76 @@
+const kpis = [
+  {
+    label: 'Total de pacientes',
+    value: '1,248',
+    trend: '+8.2% vs. mes anterior'
+  },
+  {
+    label: 'Citas programadas',
+    value: '86',
+    trend: '12 cancelaciones esta semana'
+  },
+  {
+    label: 'Ingresos del mes',
+    value: '$245,800 MXN',
+    trend: 'Objetivo alcanzado al 74%'
+  }
+];
+
+const upcomingAppointments = [
+  { id: 1, patient: 'Juan Pérez', date: '21 Mayo 2024', time: '10:00 AM', status: 'Confirmada' },
+  { id: 2, patient: 'María López', date: '21 Mayo 2024', time: '11:30 AM', status: 'Pendiente' },
+  { id: 3, patient: 'Luis Gómez', date: '21 Mayo 2024', time: '01:00 PM', status: 'Confirmada' },
+  { id: 4, patient: 'Ana Martínez', date: '22 Mayo 2024', time: '09:30 AM', status: 'Reprogramar' },
+  { id: 5, patient: 'Laura García', date: '22 Mayo 2024', time: '12:00 PM', status: 'Confirmada' }
+];
+
+const statusStyles = {
+  Confirmada: 'bg-emerald-100 text-emerald-700',
+  Pendiente: 'bg-amber-100 text-amber-700',
+  Reprogramar: 'bg-rose-100 text-rose-700'
+};
+
+export default function Dashboard() {
+  return (
+    <div className="space-y-8">
+      <section className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {kpis.map((kpi) => (
+          <article
+            key={kpi.label}
+            className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+          >
+            <p className="text-sm font-medium uppercase tracking-wide text-slate-500">{kpi.label}</p>
+            <p className="mt-3 text-3xl font-semibold text-slate-900">{kpi.value}</p>
+            <p className="mt-4 text-sm text-slate-500">{kpi.trend}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="border-b border-slate-200 px-6 py-4">
+          <h2 className="text-lg font-semibold text-slate-900">Próximas citas</h2>
+          <p className="text-sm text-slate-500">Gestión rápida de pacientes que llegan en las próximas 48 horas.</p>
+        </div>
+        <ul className="divide-y divide-slate-200">
+          {upcomingAppointments.map((appointment) => (
+            <li key={appointment.id} className="flex flex-col gap-2 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-medium text-slate-900">{appointment.patient}</p>
+                <p className="text-sm text-slate-500">
+                  {appointment.date} · {appointment.time}
+                </p>
+              </div>
+              <span
+                className={`inline-flex items-center justify-center rounded-full px-3 py-1 text-xs font-semibold ${
+                  statusStyles[appointment.status] ?? 'bg-slate-100 text-slate-600'
+                }`}
+              >
+                {appointment.status}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/PacienteDetalle.jsx
+++ b/src/pages/PacienteDetalle.jsx
@@ -1,0 +1,109 @@
+import { Link, useParams } from 'react-router-dom';
+import { CalendarDays, Home, Mail, Phone } from 'lucide-react';
+import { patientsData } from '../data/pacientes.js';
+
+export default function PacienteDetalle() {
+  const { id } = useParams();
+  const patient = patientsData.find((item) => item.id === id);
+
+  if (!patient) {
+    return (
+      <div className="space-y-4">
+        <p className="text-lg font-semibold text-slate-900">Paciente no encontrado</p>
+        <Link
+          to="/pacientes"
+          className="inline-flex items-center rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-900 hover:text-white"
+        >
+          Regresar al directorio
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Link
+        to="/pacientes"
+        className="inline-flex items-center text-sm font-medium text-slate-600 transition hover:text-slate-900"
+      >
+        ← Volver al directorio
+      </Link>
+
+      <section className="grid gap-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm lg:grid-cols-[280px,1fr]">
+        <div className="flex flex-col items-center text-center">
+          <div className="h-32 w-32 overflow-hidden rounded-full border border-slate-200">
+            <img src={patient.photo} alt={patient.name} className="h-full w-full object-cover" />
+          </div>
+          <h1 className="mt-4 text-2xl font-semibold text-slate-900">{patient.name}</h1>
+          <p className="text-sm text-slate-500">Paciente desde 2020</p>
+          <p className="mt-4 rounded-full bg-slate-100 px-4 py-1 text-xs font-semibold text-slate-700">
+            Última visita: {patient.lastVisit}
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Información de contacto</h2>
+            <dl className="mt-3 grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+              <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
+                <Phone className="h-4 w-4 text-slate-500" />
+                <div>
+                  <dt className="text-xs uppercase text-slate-400">Teléfono</dt>
+                  <dd className="font-medium text-slate-700">{patient.phone}</dd>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
+                <Mail className="h-4 w-4 text-slate-500" />
+                <div>
+                  <dt className="text-xs uppercase text-slate-400">Correo</dt>
+                  <dd className="font-medium text-slate-700">{patient.email}</dd>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 sm:col-span-2">
+                <Home className="h-4 w-4 text-slate-500" />
+                <div>
+                  <dt className="text-xs uppercase text-slate-400">Dirección</dt>
+                  <dd className="font-medium text-slate-700">{patient.address}</dd>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 sm:col-span-2">
+                <CalendarDays className="h-4 w-4 text-slate-500" />
+                <div>
+                  <dt className="text-xs uppercase text-slate-400">Fecha de nacimiento</dt>
+                  <dd className="font-medium text-slate-700">{patient.birthDate}</dd>
+                </div>
+              </div>
+            </dl>
+          </div>
+
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Notas</h2>
+            <p className="mt-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm leading-relaxed text-slate-600">
+              {patient.notes}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="border-b border-slate-200 px-6 py-4">
+          <h2 className="text-lg font-semibold text-slate-900">Historial reciente</h2>
+          <p className="text-sm text-slate-500">Últimos tratamientos registrados para el paciente.</p>
+        </div>
+        <ul className="divide-y divide-slate-200">
+          {patient.history.map((entry, index) => (
+            <li key={`${patient.id}-${index}`} className="flex flex-col gap-2 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-medium text-slate-900">{entry.treatment}</p>
+                <p className="text-sm text-slate-500">{entry.date}</p>
+              </div>
+              <span className="inline-flex rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
+                {entry.status}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Pacientes.jsx
+++ b/src/pages/Pacientes.jsx
@@ -1,0 +1,96 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Search } from 'lucide-react';
+import { patientsData } from '../data/pacientes.js';
+
+export default function Pacientes() {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState('');
+
+  const filteredPatients = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    if (!normalizedQuery) {
+      return patientsData;
+    }
+
+    return patientsData.filter((patient) =>
+      patient.name.toLowerCase().includes(normalizedQuery)
+    );
+  }, [query]);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col justify-between gap-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm md:flex-row md:items-center">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">Directorio de pacientes</h1>
+          <p className="text-sm text-slate-500">Administra la información de tus pacientes y accede rápidamente a sus expedientes.</p>
+        </div>
+        <div className="relative w-full md:w-72">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Buscar por nombre..."
+            className="w-full rounded-full border border-slate-200 bg-slate-50 py-2 pl-10 pr-4 text-sm text-slate-700 outline-none transition focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200"
+          />
+        </div>
+      </header>
+
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+          <thead className="bg-slate-50 text-xs uppercase text-slate-500">
+            <tr>
+              <th scope="col" className="px-6 py-3 font-semibold">Foto</th>
+              <th scope="col" className="px-6 py-3 font-semibold">Nombre</th>
+              <th scope="col" className="px-6 py-3 font-semibold">Teléfono</th>
+              <th scope="col" className="px-6 py-3 font-semibold">Correo</th>
+              <th scope="col" className="px-6 py-3 text-right font-semibold">Acciones</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 bg-white">
+            {filteredPatients.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-6 py-10 text-center text-sm text-slate-500">
+                  No se encontraron pacientes con ese nombre.
+                </td>
+              </tr>
+            )}
+
+            {filteredPatients.map((patient) => (
+              <tr key={patient.id} className="hover:bg-slate-50">
+                <td className="px-6 py-4">
+                  <div className="h-12 w-12 overflow-hidden rounded-full border border-slate-200">
+                    <img
+                      src={patient.photo}
+                      alt={patient.name}
+                      className="h-full w-full object-cover"
+                    />
+                  </div>
+                </td>
+                <td className="px-6 py-4">
+                  <div className="font-medium text-slate-900">{patient.name}</div>
+                  <div className="text-xs text-slate-500">Última visita: {patient.lastVisit}</div>
+                </td>
+                <td className="px-6 py-4 text-slate-600">{patient.phone}</td>
+                <td className="px-6 py-4 text-slate-600">{patient.email}</td>
+                <td className="px-6 py-4">
+                  <div className="flex justify-end">
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/pacientes/${patient.id}`)}
+                      className="rounded-full border border-slate-200 px-4 py-1 text-xs font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-900 hover:text-white"
+                    >
+                      Ver
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Reportes.jsx
+++ b/src/pages/Reportes.jsx
@@ -1,0 +1,92 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+
+const monthlyAppointments = [
+  { month: 'Ene', atendidas: 42, canceladas: 6 },
+  { month: 'Feb', atendidas: 48, canceladas: 4 },
+  { month: 'Mar', atendidas: 51, canceladas: 5 },
+  { month: 'Abr', atendidas: 47, canceladas: 3 },
+  { month: 'May', atendidas: 53, canceladas: 7 }
+];
+
+const treatmentsData = [
+  { name: 'Limpieza', value: 32 },
+  { name: 'Ortodoncia', value: 21 },
+  { name: 'Implantes', value: 15 },
+  { name: 'Resinas', value: 18 },
+  { name: 'Blanqueamiento', value: 14 }
+];
+
+const pieColors = ['#1f2937', '#0f172a', '#334155', '#64748b', '#94a3b8'];
+
+export default function Reportes() {
+  return (
+    <div className="space-y-6">
+      <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-xl font-semibold text-slate-900">Reportes</h1>
+        <p className="text-sm text-slate-500">Visualiza el desempeño de la clínica con métricas rápidas.</p>
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <article className="flex h-[360px] flex-col rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Citas atendidas vs canceladas</h2>
+            <p className="text-sm text-slate-500">Comparativo mensual de la agenda.</p>
+          </div>
+          <div className="mt-6 flex-1">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={monthlyAppointments}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                <XAxis dataKey="month" stroke="#475569" fontSize={12} />
+                <YAxis stroke="#475569" fontSize={12} allowDecimals={false} />
+                <Tooltip cursor={{ fill: 'rgba(148, 163, 184, 0.15)' }} />
+                <Legend />
+                <Bar dataKey="atendidas" fill="#1f2937" radius={[4, 4, 0, 0]} name="Atendidas" />
+                <Bar dataKey="canceladas" fill="#94a3b8" radius={[4, 4, 0, 0]} name="Canceladas" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </article>
+
+        <article className="flex h-[360px] flex-col rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Tratamientos más comunes</h2>
+            <p className="text-sm text-slate-500">Distribución de procedimientos realizados en el último trimestre.</p>
+          </div>
+          <div className="mt-6 flex-1">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={treatmentsData}
+                  cx="50%"
+                  cy="50%"
+                  outerRadius={110}
+                  innerRadius={60}
+                  paddingAngle={4}
+                  dataKey="value"
+                >
+                  {treatmentsData.map((entry, index) => (
+                    <Cell key={entry.name} fill={pieColors[index % pieColors.length]} />
+                  ))}
+                </Pie>
+                <Tooltip />
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        </article>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a left sidebar layout with header and outlet to host the main navigation
- add dashboard, patients, appointments, reports, and patient detail views with Tailwind-styled mock data
- configure BrowserRouter routing and enhance the calendar component with FullCalendar styles and props

## Testing
- npm run build *(fails: missing local Vite binary because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc86eca81483258ec956fba190388c